### PR TITLE
fix: update serialization for DestinationDefinitionRead object

### DIFF
--- a/src/models/destination_definition_read.rs
+++ b/src/models/destination_definition_read.rs
@@ -10,6 +10,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct DestinationDefinitionRead {
+    #[serde(rename="custom")]
+    pub custom: bool,
     #[serde(rename = "destinationDefinitionId")]
     pub destination_definition_id: uuid::Uuid,
     #[serde(rename = "name")]
@@ -29,7 +31,7 @@ pub struct DestinationDefinitionRead {
     pub release_stage: Option<crate::models::ReleaseStage>,
     /// The date when this connector was first released, in yyyy-mm-dd format.
     #[serde(rename = "releaseDate", skip_serializing_if = "Option::is_none")]
-    pub release_date: Option<String>,
+    pub release_date: Option<Vec<u16>>,
     #[serde(
         rename = "resourceRequirements",
         skip_serializing_if = "Option::is_none"
@@ -44,6 +46,7 @@ pub struct DestinationDefinitionRead {
 
 impl DestinationDefinitionRead {
     pub fn new(
+        custom: bool,
         destination_definition_id: uuid::Uuid,
         name: String,
         docker_repository: String,
@@ -53,6 +56,7 @@ impl DestinationDefinitionRead {
         normalization_config: crate::models::NormalizationDestinationDefinitionConfig,
     ) -> DestinationDefinitionRead {
         DestinationDefinitionRead {
+            custom,
             destination_definition_id,
             name,
             docker_repository,


### PR DESCRIPTION
### Update Serialization for DestinationDefinitionRead Object

#### Summary

This PR addresses serialization issues in the `DestinationDefinitionRead` object. The serialized JSON response was missing the `custom` field and the `release_date` was being deserialized incorrectly as a `String` instead of `Vec<u16>`.

#### Changes

- Added missing `custom` field to serialized output
- Updated the deserialization logic for `release_date` to use `Vec<u16>` instead of `String`

#### Example Serialized Response

```json
{
  "destinationDefinitionId": "65de8962-48c9-11ee-be56-0242ac120002",
  "name": "Milvus",
  "dockerRepository": "airbyte/destination-milvus",
  "dockerImageTag": "0.0.1",
  "documentationUrl": "https://docs.airbyte.com/integrations/destinations/milvus",
  "icon": "<svg...></svg>",
  "protocolVersion": "0.2.0",
  "custom": false,
  "supportLevel": "community",
  "releaseStage": "alpha",
  "releaseDate": [2023, 8, 15],
  "supportsDbt": false,
  "normalizationConfig": {
    "supported": false
  }
}
```

#### Next Steps

After merging this PR, a new version of the library should be built and published to crates.io.

Please review and if all looks good, proceed with merging.
